### PR TITLE
Feature/12 Created Readme Screens UI

### DIFF
--- a/tribomobile/App.js
+++ b/tribomobile/App.js
@@ -10,17 +10,14 @@ import React from 'react';
 import {SafeAreaView, Text, StatusBar} from 'react-native';
 import ModalInfoStore from './components/modals/ModalInfoStore';
 import LittlePin from './components/modals/LittlePinInfo';
-import titlesText from './src/titlesText';
-import contentText from './screensText/contentText';
+import RecomendationScreen from './screens/recomendationScreen';
 
 const App: () => React$Node = () => {
   return (
     <>
       <StatusBar barStyle="dark-content" />
       <SafeAreaView>
-        <ModalInfoStore />
-        <Text>Hola Tribo App</Text>
-        <LittlePin />
+        <RecomendationScreen />
       </SafeAreaView>
     </>
   );

--- a/tribomobile/screens/faqScreen.js
+++ b/tribomobile/screens/faqScreen.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import titlesText from '../src/titlesText';
+import contentText from '../screensText/contentText';
+
+const faqScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{titlesText.titleSideNavFAQ}</Text>
+      <Text style={styles.subtitle}>{titlesText.titleFAQFunciona}</Text>
+      <Text style={styles.paragraph}>{contentText.textReadmeScreenFAQP1}</Text>
+      <Text style={styles.paragraph}>{contentText.textReadmeScreenFAQP2}</Text>
+      <Text style={styles.subtitle}>{titlesText.titleFAQFunciona}</Text>
+      <Text style={styles.paragraph}>{contentText.textReadmeScreenFAQP2}</Text>
+      <Text style={styles.subtitle}>{titlesText.titleFAQFunciona}</Text>
+      <Text style={styles.paragraph}>{contentText.textReadmeScreenFAQP1}</Text>
+      <Text style={styles.subtitle}>{titlesText.titleFAQFunciona}</Text>
+      <Text style={styles.paragraph}>{contentText.textReadmeScreenFAQP1}</Text>
+      <Text style={styles.paragraph}>{contentText.textReadmeScreenFAQP2}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 40,
+  },
+  title: {
+    color: '#4A4A4A',
+    fontWeight: 'bold',
+    fontSize: 25,
+    textAlign: 'center',
+    marginBottom: 40,
+  },
+  subtitle: {
+    color: '#939393',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  paragraph: {
+    color: '#939393',
+    fontSize: 16,
+    marginBottom: 15,
+  },
+});
+
+export default faqScreen;

--- a/tribomobile/screens/policyScreen.js
+++ b/tribomobile/screens/policyScreen.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import titlesText from '../src/titlesText';
+import contentText from '../screensText/contentText';
+
+const policyScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{titlesText.titleSideNavPolicy}</Text>
+      <Text style={styles.paragraph}>
+        {contentText.textReadmeScreenPoliticaP1}
+      </Text>
+      <Text style={styles.paragraph}>
+        {contentText.textReadmeScreenPoliticaP2}
+      </Text>
+      <Text style={styles.paragraph}>
+        {contentText.textReadmeScreenPoliticaP3}
+      </Text>
+      <Text style={styles.paragraph}>
+        {contentText.textReadmeScreenPoliticaP4}
+      </Text>
+      <Text style={styles.paragraph}>
+        {contentText.textReadmeScreenPoliticaP5}
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 40,
+  },
+  title: {
+    color: '#4A4A4A',
+    fontWeight: 'bold',
+    fontSize: 25,
+    textAlign: 'center',
+    marginTop: 10,
+    marginBottom: 20,
+  },
+  paragraph: {
+    color: '#939393',
+    fontSize: 16,
+    marginTop: 25,
+  },
+});
+
+export default policyScreen;

--- a/tribomobile/screens/recomendationScreen.js
+++ b/tribomobile/screens/recomendationScreen.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import titlesText from '../src/titlesText';
+import contentText from '../screensText/contentText';
+
+const recomendationScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{titlesText.titleStayHome}</Text>
+      <Text style={styles.subtitle}>{titlesText.titleRecomendations}</Text>
+      <Text style={styles.paragraph}>
+        {contentText.textReadmeScreenRecomendacionesP1}
+      </Text>
+      <Text style={styles.paragraph}>
+        {contentText.textReadmeScreenRecomendacionesP2}
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 40,
+  },
+  title: {
+    color: '#4A4A4A',
+    fontWeight: 'bold',
+    fontSize: 25,
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  subtitle: {
+    color: '#1F1F1F',
+    fontWeight: 'bold',
+    fontSize: 20,
+    marginBottom: 20,
+  },
+  paragraph: {
+    color: '#939393',
+    fontSize: 16,
+    marginBottom: 20,
+  },
+});
+
+export default recomendationScreen;

--- a/tribomobile/screens/termsScreen.js
+++ b/tribomobile/screens/termsScreen.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import titlesText from '../src/titlesText';
+import contentText from '../screensText/contentText';
+
+const termsScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{titlesText.titleSideNavTerms}</Text>
+      <Text style={styles.paragraph}>
+        {contentText.textReadmeScreenTerminosP1}
+      </Text>
+      <Text style={styles.paragraph}>
+        {contentText.textReadmeScreenTerminosP2}
+      </Text>
+      <Text style={styles.paragraph}>
+        {contentText.textReadmeScreenTerminosP3}
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 40,
+  },
+  title: {
+    color: '#4A4A4A',
+    fontWeight: 'bold',
+    fontSize: 25,
+    textAlign: 'center',
+    marginTop: 10,
+    marginBottom: 20,
+  },
+  paragraph: {
+    color: '#939393',
+    fontSize: 16,
+    marginTop: 25,
+  },
+});
+
+export default termsScreen;


### PR DESCRIPTION
# Description
Created the 4 readme screens as the issue #12 declares  / It was implemented in order to complete the corresponding issue:
- Basically I created a screens folder to storage the 4 readme screens. 
- Once the files were created I implemented the tittlesText and contentText in each screen. 
- Also added the corresponding styles and colors(Colors hasn't been defined yet so I implemented some hex colors based on the corresponding design here https://miro.com/app/board/o9J_ktv22zI=/?moveToWidget=3074457347673574370&cot=12).
- Tested the proper functionality and also compared them with the above example.
  
 # Testing
- Go to feature/12 branch ( git checkout feature/12-Readme-Screen-UI ).
- Open it ( code . ).
- npm install in case you do not see the node modules.
- npx react-native start.
- npx react-native run-android.
- You will see the (<RecomendationScreen /> but if you want to see the others just change this 
![image](https://user-images.githubusercontent.com/69820530/102273699-5e475500-3ee8-11eb-8c17-46ef7cd07799.png) for another screen name like faqScreen, policyScreen or termsScreen).
 
  ## Screenshots 
-------------------------------------------------- Provided Example ----------------------------------------------------------------

![image](https://user-images.githubusercontent.com/69820530/102273445-f5f87380-3ee7-11eb-9968-c3f8e3e770ef.png)

-------------------------------------------------- How it looks like ------------------------------------------------------------------

![image](https://user-images.githubusercontent.com/69820530/102273174-8aaea180-3ee7-11eb-96b5-f18921dc4a49.png)
![image](https://user-images.githubusercontent.com/69820530/102273213-9a2dea80-3ee7-11eb-8daf-8a3bf75084c6.png)
![image](https://user-images.githubusercontent.com/69820530/102273241-a44fe900-3ee7-11eb-8726-52b256a53baf.png)
![image](https://user-images.githubusercontent.com/69820530/102273274-ae71e780-3ee7-11eb-8da3-22650056e17d.png)

