### PR TITLE
add design to edit account screen

### DIFF
--- a/tribomobile/App.js
+++ b/tribomobile/App.js
@@ -10,7 +10,8 @@ import React from 'react';
 import {SafeAreaView, Text, StatusBar, Modal} from 'react-native';
 import WelcomeScreen from './components/screens/welcome/WelcomeScreen';
 import LoadingScreen from './components/screens/welcome/LoadingScreen';
-import LoginScreen from './screens/Login'
+import LoginScreen from './screens/Login';
+import EditAccountScreen from './screens/profile/EditAccountScreen';
 
 import {
   ModalDeleteStore,
@@ -19,15 +20,15 @@ import {
 import ModalInfoStore from './components/modals/LittlePinInfo';
 
 const App: () => React$Node = () => {
-  const nameBusinessDummy = 'La fonda de Doña Luisa';
-  const fullTextExampleWhenDeleteABussiness = `${ModalDeleteStoreTexts.description.business} "${nameBusinessDummy}" ?`;
+  const userDummy = {
+    name: 'Daniel Peña Sanchez',
+    email: 'daniel.peña@gmail.com',
+  };
   return (
     <>
       <StatusBar barStyle="dark-content" />
       <SafeAreaView>
-        {/* <WelcomeScreen /> */}
-        {/* <LoadingScreen /> */}
-        <LoginScreen />
+        <EditAccountScreen userAccount={userDummy} />
       </SafeAreaView>
     </>
   );

--- a/tribomobile/components/TextInputs.js
+++ b/tribomobile/components/TextInputs.js
@@ -3,7 +3,7 @@ import {StyleSheet, TextInput, TouchableOpacity} from 'react-native';
 import Colors from '../src/Colors';
 
 const TextInputs = (props) => {
-  const {textInputType, placeholderText} = props;
+  const {textInputType, placeholderText, value} = props;
 
   const textInputStyling = (textInputType) => {
     let styleProperties = [];
@@ -40,6 +40,7 @@ const TextInputs = (props) => {
       placeholderTextColor={
         textInputType === 'textInputNull' ? Colors.Red : Colors.GrayDark
       }
+      value={value || ''}
     />
   );
 };

--- a/tribomobile/screens/Login.js
+++ b/tribomobile/screens/Login.js
@@ -5,9 +5,10 @@ import {CustomButton, ConfigBtnCustom} from '../components/CustomButton';
 import TriboLogo from '../assets/tribologo.png';
 import TextInputCustom from '../components/TextInputs';
 import Colors from '../src/Colors';
+import Logo from '../components/LogoTribo';
 
 //textInputNull
-function WelcomeScreen() {
+function LoginScreen() {
   const [error, setError] = useState(false);
   return (
     <View style={styles.container}>
@@ -100,4 +101,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default WelcomeScreen;
+export default LoginScreen;

--- a/tribomobile/screens/profile/EditAccountScreen.js
+++ b/tribomobile/screens/profile/EditAccountScreen.js
@@ -1,0 +1,128 @@
+import React, {useState} from 'react';
+import {StyleSheet, Text, View, TouchableOpacity, Image} from 'react-native';
+import TitlesText from '../../src/TitlesText';
+import {CustomButton, ConfigBtnCustom} from '../../components/CustomButton';
+import TriboLogo from '../../assets/tribologo.png';
+import TextInputCustom from '../../components/TextInputs';
+import Colors from '../../src/Colors';
+import Logo from '../../components/LogoTribo';
+
+//textInputNull
+function EditAccountScreen(props) {
+  const {userAccount} = props;
+  const [error, setError] = useState(false);
+  return (
+    <View style={styles.container}>
+      <View style={styles.containerLogo}>
+        <Image style={styles.triboLogo} source={TriboLogo} />
+      </View>
+      <Text style={styles.textBold}>{TitlesText.titleProfileEditAccount}</Text>
+      <Text style={styles.textInput}>{TitlesText.titleProfileName}</Text>
+      <TextInputCustom
+        textInputType={'searchBar'}
+        placeholderText={TitlesText.titleProfileName}
+        value={userAccount?.name}
+      />
+      <Text style={styles.textInput}>{TitlesText.titleProfileEmail}</Text>
+      <TextInputCustom
+        textInputType={'searchBar'}
+        placeholderText={TitlesText.titleProfileEmail}
+        value={userAccount?.email}
+      />
+      {error && (
+        <Text style={styles.textError}>
+          {TitlesText.titleProfilePasswordIncorrect}
+        </Text>
+      )}
+      <Text style={styles.textChangePassword}>
+        {TitlesText.titleProfileChangePassword}
+      </Text>
+      <View style={styles.containerButtons}>
+        <CustomButton
+          size={ConfigBtnCustom.SIZE.SMALL}
+          titleSize={ConfigBtnCustom.TITLE_SIZE.SMALL}
+          bgBtn={ConfigBtnCustom.COLOR.DISABLED}
+          borderColorBtn={ConfigBtnCustom.COLOR.DISABLED}
+          titleColor={ConfigBtnCustom.COLOR.WHITE}
+          widthBtn={'90%'}
+          title={'Cancelar'}
+          marginTop={20}
+          disabled={false}
+        />
+        <CustomButton
+          size={ConfigBtnCustom.SIZE.SMALL}
+          titleSize={ConfigBtnCustom.TITLE_SIZE.SMALL}
+          bgBtn={ConfigBtnCustom.COLOR.GREEN}
+          borderColorBtn={ConfigBtnCustom.COLOR.GREEN}
+          titleColor={ConfigBtnCustom.COLOR.WHITE}
+          widthBtn={'90%'}
+          title={'Guardar'}
+          marginTop={20}
+          disabled={false}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: '100%',
+  },
+  triboLogo: {
+    marginTop: 70,
+    marginBottom: 35,
+    alignSelf: 'center',
+    width: 195,
+    height: 65,
+  },
+  textBold: {
+    fontSize: 30,
+    marginTop: 25,
+    marginHorizontal: 40,
+    marginBottom: 20,
+    fontWeight: 'bold',
+  },
+  textInput: {
+    fontSize: 24,
+    marginHorizontal: 40,
+    fontWeight: 'bold',
+  },
+  textChangePassword: {
+    color: '#037D94',
+    fontSize: 23,
+    marginHorizontal: 40,
+    fontWeight: 'bold',
+  },
+  containerButtons: {
+    flexDirection: 'row',
+    height: 50,
+    width: '75%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 30,
+    marginHorizontal: 50,
+  },
+  textNotAccount: {
+    fontSize: 16,
+  },
+  textRegisterHere: {
+    fontSize: 16,
+    color: '#037D94',
+    fontWeight: 'bold',
+  },
+  containerLogo: {
+    borderBottomWidth: 3,
+    borderBottomColor: '#E5E5E5',
+    width: '90%',
+    marginHorizontal: 25,
+  },
+  textError: {
+    color: Colors.Red,
+    marginHorizontal: 20,
+    textAlign: 'center',
+    fontSize: 15,
+  },
+});
+
+export default EditAccountScreen;

--- a/tribomobile/screens/profile/EditAccountScreen.js
+++ b/tribomobile/screens/profile/EditAccountScreen.js
@@ -31,7 +31,7 @@ function EditAccountScreen(props) {
       />
       {error && (
         <Text style={styles.textError}>
-          {TitlesText.titleProfilePasswordIncorrect}
+          {TitlesText.titleProfileEmaildIncorrect}
         </Text>
       )}
       <Text style={styles.textChangePassword}>

--- a/tribomobile/src/TitlesText.js
+++ b/tribomobile/src/TitlesText.js
@@ -11,6 +11,12 @@ export default TitlesText = {
   titleNotAccount: '¿Aún no tienes cuenta?',
   titleRegisteHere: 'Registrate aquí',
   titleLoginError: 'El número telefónico no existe o la contraseña es incorrecta',
+  //Profile
+  titleProfileEditAccount: 'Editar mi cuenta',
+  titleProfileName: 'Nombre Completo',
+  titleProfileEmail: 'Correo Electrónico',
+  titleProfileChangePassword: 'Cambiar contraseña',
+  titleProfilePasswordIncorrect: 'Contraseña no válida',
   //welcomescreens
   titleSplashGreeting: '¡Hola!',
   titleSplashWelcome: 'Te damos la bienvenida a',

--- a/tribomobile/src/TitlesText.js
+++ b/tribomobile/src/TitlesText.js
@@ -16,7 +16,7 @@ export default TitlesText = {
   titleProfileName: 'Nombre Completo',
   titleProfileEmail: 'Correo Electrónico',
   titleProfileChangePassword: 'Cambiar contraseña',
-  titleProfilePasswordIncorrect: 'Contraseña no válida',
+  titleProfileEmaildIncorrect: 'Correo no válida',
   //welcomescreens
   titleSplashGreeting: '¡Hola!',
   titleSplashWelcome: 'Te damos la bienvenida a',


### PR DESCRIPTION
# Description
What did you implemented/Why did you implemented this:
 - add screen layout as is in figma
 - reuse previously created components
 - add a prop "value" to input textalong.
 
 Examples:
 - What?: I have made the layout of the edit account screen
 - Why?: because it is a necessary functionality of the user
 
 # Testing

- `git clone https://github.com/BrightCoders-Proyectos/tribo-mobile/tree/feature/64-ScreenProfile-EditAccount`
- `npm install`
- `npx react native run-android` or `npx react-native run-ios`
- open app
 
 Example:
  - I've added coverage for testing all new methods. I used Faker for a few random user emails and names.
  
  ## Screenshots 
If applicable, include screenshots of the results or screenshots that help to see changes
![image](https://user-images.githubusercontent.com/69357302/107957603-737f4500-6f66-11eb-847a-514a03071c56.png)
![image](https://user-images.githubusercontent.com/69357302/107957622-7843f900-6f66-11eb-8441-52bc947e3f1b.png)

