### PR TITLE
Feature/delete account or bussiness

### DIFF
--- a/tribomobile/App.js
+++ b/tribomobile/App.js
@@ -37,8 +37,8 @@ const App: () => React$Node = () => {
     <>
       <StatusBar barStyle="dark-content" />
       <SafeAreaView>
-        <RegistrationScreen/>
-        {/* <ExampleButtons/> */}
+        {/* <RegistrationScreen/> */}
+        <EditAccountScreen userAccount={userDummy}/>
       </SafeAreaView>
     </>
   );

--- a/tribomobile/App.js
+++ b/tribomobile/App.js
@@ -16,17 +16,17 @@ import MainScreen from './components/MainScreen';
 import ModalInfoStore from './components/modals/ModalInfoStore';
 import LittlePinInfo from './components/modals/LittlePinInfo';
 import SideNavScreen from './screens/SideNavScreen';
-import RegisterMarket  from './screens/RegisterMarket';
-import RegistrationScreen  from './screens/RegistrationScreen';
+import RegisterMarket from './screens/RegisterMarket';
+import RegistrationScreen from './screens/RegistrationScreen';
 import WelcomeScreen from './components/screens/welcome/WelcomeScreen';
 import LoadingScreen from './components/screens/welcome/LoadingScreen';
 import LoginScreen from './screens/Login';
 import EditAccountScreen from './screens/profile/EditAccountScreen';
 
 import {
-  ModalDeleteStore,
-  ModalDeleteStoreTexts,
-} from './components/modals/ModalDeleteStore';
+  ModalDeleteStoreOrAccount,
+  ModalDeleteTexts,
+} from './components/modals/ModalDeleteStoreOrAccout';
 
 const App: () => React$Node = () => {
   const userDummy = {
@@ -37,8 +37,15 @@ const App: () => React$Node = () => {
     <>
       <StatusBar barStyle="dark-content" />
       <SafeAreaView>
-        {/* <RegistrationScreen/> */}
-        <EditAccountScreen userAccount={userDummy}/>
+        <ModalDeleteStoreOrAccount
+          isBussiness={true}
+          title={ModalDeleteTexts.title.business}
+          description={'La fonda de doña luisa'}
+        />
+        <ModalDeleteStoreOrAccount
+          title={ModalDeleteTexts.title.account}
+          description={ModalDeleteTexts.description.account}
+        />
       </SafeAreaView>
     </>
   );

--- a/tribomobile/components/TextInputs.js
+++ b/tribomobile/components/TextInputs.js
@@ -40,7 +40,7 @@ const TextInputs = (props) => {
       placeholderTextColor={
         textInputType === 'textInputNull' ? Colors.Red : Colors.GrayDark
       }
-      value={value || ''}
+      defaultValue={value}
     />
   );
 };

--- a/tribomobile/components/modals/ModalDeleteStoreOrAccout.js
+++ b/tribomobile/components/modals/ModalDeleteStoreOrAccout.js
@@ -23,7 +23,7 @@ function Description(props) {
   );
 }
 
-const ModalDeleteStoreTexts = {
+const ModalDeleteTexts = {
   title: {
     business: TitlesText.titleDeleteBusiness,
     account: TitlesText.titleDeleteAccount,
@@ -35,9 +35,14 @@ const ModalDeleteStoreTexts = {
   },
 };
 
-function ModalDeleteStore(props) {
-  const {title, description} = props;
+function ModalDeleteStoreOrAccount(props) {
+  const {title, description, isBussiness} = props;
   const [modalVisible, setModalVisible] = useState(false);
+  let newDescription='';
+  if (isBussiness) {
+    newDescription = `${ModalDeleteTexts.description.business} 
+    "${description}" ${ModalDeleteTexts.description.interrogationSimbol}`;
+  }
 
   const closeModal = () => {
     setModalVisible(!modalVisible);
@@ -62,7 +67,7 @@ function ModalDeleteStore(props) {
               </View>
               <Description
                 title={title}
-                information={description}
+                information={isBussiness ? newDescription : description}
                 style={styles.description}
               />
               <View style={styles.containerButtons}>
@@ -94,13 +99,17 @@ function ModalDeleteStore(props) {
         </Modal>
       </View>
 
-      <TouchableOpacity
-        style={styles.openButton}
-        onPress={() => {
-          setModalVisible(true);
-        }}>
-        <Text style={styles.textStyle}>Show Modal delete</Text>
-      </TouchableOpacity>
+      <CustomButton
+        size={ConfigBtnCustom.SIZE.SMALL}
+        titleSize={ConfigBtnCustom.TITLE_SIZE.SMALL}
+        bgBtn={ConfigBtnCustom.COLOR.DISABLED}
+        borderColorBtn={ConfigBtnCustom.COLOR.DISABLED}
+        titleColor={ConfigBtnCustom.COLOR.WHITE}
+        widthBtn={isBussiness ? '40%' : '80%'}
+        title={isBussiness ? 'Eliminar' : 'Borrar Cuenta'}
+        disabled={false}
+        action={() => setModalVisible(true)}
+      />
     </>
   );
 }
@@ -114,7 +123,7 @@ const styles = StyleSheet.create({
   modalView: {
     margin: 20,
     backgroundColor: '#f7f4f4',
-    borderRadius: 7,
+    borderRadius: 15,
     paddingTop: 25,
     paddingBottom: 40,
     shadowColor: '#000',
@@ -156,6 +165,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: 'black',
     textAlign: 'center',
+    marginBottom: 20,
   },
   descriptionInfo: {
     color: 'black',
@@ -166,12 +176,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     paddingHorizontal: 10,
+    paddingTop: 35,
   },
 });
 
-ModalDeleteStore.propTypes = {
+ModalDeleteStoreOrAccount.propTypes = {
   title: PropTypes.string,
   description: PropTypes.string,
 };
 
-export {ModalDeleteStore, ModalDeleteStoreTexts};
+export {ModalDeleteStoreOrAccount, ModalDeleteTexts};


### PR DESCRIPTION
# Description
What did you implemented/Why did you implemented this:
 - design the manners to delete account or business
 - reusing previously created components
 - design the buttons that open those manners
 
 
 # Testing

- `git clone https://github.com/BrightCoders-Proyectos/tribo-mobile/tree/feature/delete-accountOrBussiness`
- `npm install`
- `npx react native run-android` or `npx react-native run-ios`
- open app
- 
  
  ## Screenshots 
import for both:
`import {
  ModalDeleteStoreOrAccount,
  ModalDeleteTexts,
} from './components/modals/ModalDeleteStoreOrAccout';
`
-  delete account

aplicar
`<ModalDeleteStoreOrAccount
          title={ModalDeleteTexts.title.account}
          description={ModalDeleteTexts.description.account}
        />`
![image](https://user-images.githubusercontent.com/69357302/108023582-702c9d80-6fe8-11eb-8b1d-13ea007d3225.png)
![image](https://user-images.githubusercontent.com/69357302/108023589-7753ab80-6fe8-11eb-9900-b1779d4a45b3.png)

- delete bussiness
 aplicar
`<ModalDeleteStoreOrAccount
          isBussiness={true}
          title={ModalDeleteTexts.title.business}
          description={'La fonda de doña luisa'}
        />`
![image](https://user-images.githubusercontent.com/69357302/108023755-e0d3ba00-6fe8-11eb-8498-009ff023aa0a.png)
![image](https://user-images.githubusercontent.com/69357302/108023762-e6310480-6fe8-11eb-9ad0-2b03cc328ab2.png)


